### PR TITLE
Updated binder and ashmem drivers to work with newer kernels

### DIFF
--- a/driver/ashmem/ashmem.c
+++ b/driver/ashmem/ashmem.c
@@ -863,13 +863,9 @@ static int __init ashmem_init(void)
 
 static void __exit ashmem_exit(void)
 {
-	int ret;
-
 	unregister_shrinker(&ashmem_shrinker);
 
-	ret = misc_deregister(&ashmem_misc);
-	if (unlikely(ret))
-		pr_err("failed to unregister misc device!\n");
+	misc_deregister(&ashmem_misc);
 
 	kmem_cache_destroy(ashmem_range_cachep);
 	kmem_cache_destroy(ashmem_area_cachep);

--- a/driver/binder/binder.c
+++ b/driver/binder/binder.c
@@ -3700,11 +3700,7 @@ static int __init binder_init(void)
 
 static void __exit binder_exit(void)
 {
-	int ret;
-
-	ret = misc_deregister(&binder_miscdev);
-	if (unlikely(ret))
-		pr_err("failed to unregister misc device!\n");
+	misc_deregister(&binder_miscdev);
 
 	if (binder_deferred_workqueue)
 		destroy_workqueue(binder_deferred_workqueue);


### PR DESCRIPTION
Removed checking of return value from misc_deregister as the function returns void in newer kernels.  This will allow the drivers to build with Ubuntu 16.04 and other kernels for newer distros.